### PR TITLE
Fix undefined behavior with CString usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zonename"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Dave Eddy <dave@daveeddy.com>", "Mike Zeller <mike@mikezeller.net>"]
 description = "Bindings to getzoneid(3C), getzoneidbyname(3C), and getzonenamebyid(3C) for illumos based systems."
 repository = "https://github.com/bahamas10/rust-zonename"


### PR DESCRIPTION
Fix use of CString::from_raw based upon:
This should only ever be called with a pointer that was earlier obtained by calling into_raw on a CString.